### PR TITLE
Updated test to use AcceptedDate instead of Accepted+

### DIFF
--- a/deploy/App.txt
+++ b/deploy/App.txt
@@ -3,13 +3,13 @@
 <head>
     <title>Revamped Validation App</title>
     <!--  (c) 2016 CA Technologies.  All Rights Reserved. -->
-    <!--  Build Date: Tue Aug 23 2016 10:28:17 GMT-0400 (EDT) -->
+    <!--  Build Date: Tue Aug 23 2016 13:32:33 GMT-0400 (EDT) -->
     
     <script type="text/javascript">
-        var APP_BUILD_DATE = "Tue Aug 23 2016 10:28:17 GMT-0400 (EDT)";
+        var APP_BUILD_DATE = "Tue Aug 23 2016 13:32:33 GMT-0400 (EDT)";
         var STORY    = "US569";
         var BUILDER  = "srhoads";
-        var CHECKSUM = 65862608521;
+        var CHECKSUM = 66242463003;
     </script>
     
     <script type="text/javascript" src="/apps/2.1/sdk.js"></script>
@@ -294,7 +294,7 @@ Ext.define('CA.techservices.validation.DefectAcceptedNotClosed',{
     },
     
     getFetchFields: function() {
-        return ['Name','ScheduleState','State'];
+        return ['Name','ScheduleState','State','AcceptedDate'];
     },
     
     isValidField: function(model, field_name) {
@@ -307,9 +307,9 @@ Ext.define('CA.techservices.validation.DefectAcceptedNotClosed',{
 
 console.log("applyRuleToRecord",record);
         // using fact that the system populates the AcceptedDate... for Accepted and higher ScheduleStates...
-      //  if (( record.get('AcceptedDate') != null ) && (record.get('State') != "Closed") ) {
-        if (( record.get('ScheduleState') == "Accepted" ) && (record.get('State') != "Closed") ) {
-            var msg = "Accepted Defects should additionally be Closed.";
+        if (( record.get('AcceptedDate') != null ) && (record.get('State') != "Closed") ) {
+        // if (( record.get('ScheduleState') == "Accepted" ) && (record.get('State') != "Closed") ) {
+            var msg = Ext.String.format("Accepted Defects should additionally be Closed.(SchedState={0}: State={1})",record.get('ScheduleState'),record.get('State'));
             return msg;   
         } 
         return null; // no rule violation
@@ -318,8 +318,8 @@ console.log("applyRuleToRecord",record);
     getFilters: function() {        
         return Rally.data.wsapi.Filter.and([
             {property:'State',operator:'!=',value:'Closed'},
-            //{property:'AcceptedDate',operator:'!=',value:null}
-            {property:'ScheduleState',operator:'=',value:'Accepted'}
+            {property:'AcceptedDate',operator:'!=',value:null}
+            //{property:'ScheduleState',operator:'=',value:'Accepted'}
         ]);
     }
 });

--- a/deploy/App.txt
+++ b/deploy/App.txt
@@ -3,13 +3,13 @@
 <head>
     <title>Revamped Validation App</title>
     <!--  (c) 2016 CA Technologies.  All Rights Reserved. -->
-    <!--  Build Date: Tue Aug 23 2016 09:53:20 GMT-0400 (EDT) -->
+    <!--  Build Date: Tue Aug 23 2016 10:28:17 GMT-0400 (EDT) -->
     
     <script type="text/javascript">
-        var APP_BUILD_DATE = "Tue Aug 23 2016 09:53:20 GMT-0400 (EDT)";
+        var APP_BUILD_DATE = "Tue Aug 23 2016 10:28:17 GMT-0400 (EDT)";
         var STORY    = "US569";
         var BUILDER  = "srhoads";
-        var CHECKSUM = 61605701667;
+        var CHECKSUM = 65862608521;
     </script>
     
     <script type="text/javascript" src="/apps/2.1/sdk.js"></script>
@@ -275,6 +275,52 @@ Ext.define('CA.techservices.validation.BaseRule',{
     
     getUserFriendlyRuleLabel: function() {        
         return this.label;
+    }
+});
+Ext.define('CA.techservices.validation.DefectAcceptedNotClosed',{
+    extend: 'CA.techservices.validation.BaseRule',
+    alias:  'widget.tsdefectacceptednotclosedrule',
+    
+    config: {
+        model: 'Defect',
+        label: 'Accepted Defect Not Closed'
+    },
+    
+    getDescription: function() {
+        return Ext.String.format("<strong>{0}</strong>: {1}",
+            this.label,
+            "Accepted Defects should additionally be Closed."
+        );
+    },
+    
+    getFetchFields: function() {
+        return ['Name','ScheduleState','State'];
+    },
+    
+    isValidField: function(model, field_name) {
+        var field_defn = model.getField(field_name);
+        return ( !Ext.isEmpty(field_defn) );
+    },
+    
+    applyRuleToRecord: function(record) {
+        //var missingFields = [];
+
+console.log("applyRuleToRecord",record);
+        // using fact that the system populates the AcceptedDate... for Accepted and higher ScheduleStates...
+      //  if (( record.get('AcceptedDate') != null ) && (record.get('State') != "Closed") ) {
+        if (( record.get('ScheduleState') == "Accepted" ) && (record.get('State') != "Closed") ) {
+            var msg = "Accepted Defects should additionally be Closed.";
+            return msg;   
+        } 
+        return null; // no rule violation
+    },
+    
+    getFilters: function() {        
+        return Rally.data.wsapi.Filter.and([
+            {property:'State',operator:'!=',value:'Closed'},
+            //{property:'AcceptedDate',operator:'!=',value:null}
+            {property:'ScheduleState',operator:'=',value:'Accepted'}
+        ]);
     }
 });
 Ext.define('CA.techservices.validation.DefectClosedNoResolution',{
@@ -1431,7 +1477,8 @@ Ext.define("TSValidationApp", {
             {xtype:'tsstoryreleasenoteqfeaturereleaseexcludeunfinishedrule'}
         ],
         Defect: [
-            {xtype:'tsdefectclosednoresolutionrule'}
+            {xtype:'tsdefectclosednoresolutionrule'},
+            {xtype:'tsdefectacceptednotclosedrule'}
         ],
         Task: [
             {xtype:'tstaskrequiredfieldrule',  requiredFields: ['Owner']},

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -68,7 +68,8 @@ Ext.define("TSValidationApp", {
             {xtype:'tsstoryreleasenoteqfeaturereleaseexcludeunfinishedrule'}
         ],
         Defect: [
-            {xtype:'tsdefectclosednoresolutionrule'}
+            {xtype:'tsdefectclosednoresolutionrule'},
+            {xtype:'tsdefectacceptednotclosedrule'}
         ],
         Task: [
             {xtype:'tstaskrequiredfieldrule',  requiredFields: ['Owner']},

--- a/src/javascript/rules/_ts-validation-rule-defect-accepted-not-closed.js
+++ b/src/javascript/rules/_ts-validation-rule-defect-accepted-not-closed.js
@@ -1,0 +1,46 @@
+Ext.define('CA.techservices.validation.DefectAcceptedNotClosed',{
+    extend: 'CA.techservices.validation.BaseRule',
+    alias:  'widget.tsdefectacceptednotclosedrule',
+    
+    config: {
+        model: 'Defect',
+        label: 'Accepted Defect Not Closed'
+    },
+    
+    getDescription: function() {
+        return Ext.String.format("<strong>{0}</strong>: {1}",
+            this.label,
+            "Accepted Defects should additionally be Closed."
+        );
+    },
+    
+    getFetchFields: function() {
+        return ['Name','ScheduleState','State'];
+    },
+    
+    isValidField: function(model, field_name) {
+        var field_defn = model.getField(field_name);
+        return ( !Ext.isEmpty(field_defn) );
+    },
+    
+    applyRuleToRecord: function(record) {
+        //var missingFields = [];
+
+console.log("applyRuleToRecord",record);
+        // using fact that the system populates the AcceptedDate... for Accepted and higher ScheduleStates...
+      //  if (( record.get('AcceptedDate') != null ) && (record.get('State') != "Closed") ) {
+        if (( record.get('ScheduleState') == "Accepted" ) && (record.get('State') != "Closed") ) {
+            var msg = "Accepted Defects should additionally be Closed.";
+            return msg;   
+        } 
+        return null; // no rule violation
+    },
+    
+    getFilters: function() {        
+        return Rally.data.wsapi.Filter.and([
+            {property:'State',operator:'!=',value:'Closed'},
+            //{property:'AcceptedDate',operator:'!=',value:null}
+            {property:'ScheduleState',operator:'=',value:'Accepted'}
+        ]);
+    }
+});

--- a/src/javascript/rules/_ts-validation-rule-defect-accepted-not-closed.js
+++ b/src/javascript/rules/_ts-validation-rule-defect-accepted-not-closed.js
@@ -15,7 +15,7 @@ Ext.define('CA.techservices.validation.DefectAcceptedNotClosed',{
     },
     
     getFetchFields: function() {
-        return ['Name','ScheduleState','State'];
+        return ['Name','ScheduleState','State','AcceptedDate'];
     },
     
     isValidField: function(model, field_name) {
@@ -28,9 +28,9 @@ Ext.define('CA.techservices.validation.DefectAcceptedNotClosed',{
 
 console.log("applyRuleToRecord",record);
         // using fact that the system populates the AcceptedDate... for Accepted and higher ScheduleStates...
-      //  if (( record.get('AcceptedDate') != null ) && (record.get('State') != "Closed") ) {
-        if (( record.get('ScheduleState') == "Accepted" ) && (record.get('State') != "Closed") ) {
-            var msg = "Accepted Defects should additionally be Closed.";
+        if (( record.get('AcceptedDate') != null ) && (record.get('State') != "Closed") ) {
+        // if (( record.get('ScheduleState') == "Accepted" ) && (record.get('State') != "Closed") ) {
+            var msg = Ext.String.format("Accepted Defects should additionally be Closed.(SchedState={0}: State={1})",record.get('ScheduleState'),record.get('State'));
             return msg;   
         } 
         return null; // no rule violation
@@ -39,8 +39,8 @@ console.log("applyRuleToRecord",record);
     getFilters: function() {        
         return Rally.data.wsapi.Filter.and([
             {property:'State',operator:'!=',value:'Closed'},
-            //{property:'AcceptedDate',operator:'!=',value:null}
-            {property:'ScheduleState',operator:'=',value:'Accepted'}
+            {property:'AcceptedDate',operator:'!=',value:null}
+            //{property:'ScheduleState',operator:'=',value:'Accepted'}
         ]);
     }
 });


### PR DESCRIPTION
Added appSetting for Defect Rules, Updated App.js to contain a Defect rules group, added rule (and created it).

Updated test to use Accepted date so that Defects in a ScheduleState beyond Accepted are also OK. Updated popup message to show desired and current values.
